### PR TITLE
Improved the web interface and sensorNode communciation

### DIFF
--- a/data/script.js
+++ b/data/script.js
@@ -210,6 +210,44 @@ function updateSensorData(data) {
         historyButton.style.display = 'none';
         roomDiv.appendChild(historyButton);
 
+        // Add sleep period dropdown
+        const sleepLabel = document.createElement('label');
+        sleepLabel.setAttribute('for', `sleep-${data.room_id}`);
+        sleepLabel.textContent = `Sleep Period: `;
+        roomDiv.appendChild(sleepLabel);
+
+        const sleepSelect = document.createElement('select');
+
+        sleepSelect.id = `sleep-${data.room_id}`;
+        const options = [
+            { text: '5 min', value: '5min' },
+            { text: '15 min', value: '15min' },
+            { text: '30 min', value: '30min' },
+            { text: '1 h', value: '1h' },
+            { text: '3 h', value: '3h' },
+            { text: '6 h', value: '6h' },
+        ];
+
+        options.forEach(opt => {
+            const optionElement = document.createElement('option');
+            optionElement.value = opt.value;
+            optionElement.textContent = opt.text;
+            sleepSelect.appendChild(optionElement);
+        });
+
+        sleepSelect.onchange = () => {
+            const selected = sleepSelect.value;
+            const message = {
+                action: "setSleepPeriod",
+                room_id: data.room_id,
+                sleep_period: selected
+            };
+            socket.send(JSON.stringify(message));
+            console.log(`Sent sleep period update: ${JSON.stringify(message)}`);
+        };
+
+        roomDiv.appendChild(sleepSelect);
+
         const warmPara = document.createElement('p');
         warmPara.id = `warm-${data.room_id}`;
         roomDiv.appendChild(warmPara);
@@ -229,6 +267,12 @@ function updateSensorData(data) {
         } else {
             console.log(`Room ${data.room_id} is not registered or data value is undefined.`);
         }
+    }
+
+
+    const sleepSelect = document.getElementById(`sleep-${data.room_id}`);
+    if (sleepSelect && typeof data.sleep_period_ms !== 'undefined'){
+        sleepSelect.value = sleepMsToStr(data.sleep_period_ms);
     }
 
     // Update displayed sensor values

--- a/include/MasterDevice/MasterController.h
+++ b/include/MasterDevice/MasterController.h
@@ -23,12 +23,11 @@
 // Structure to track pending updates for rooms
 struct PendingUpdate {
     uint8_t room_id;            // Room identifier
-    NodeType node_type;         // Type of node (SENSOR or ROOM)
     uint8_t attempts;           // Number of resend attempts
     uint32_t lastAttemptMillis; // Timestamp of the last attempt
 
     PendingUpdate() 
-        : room_id(0), node_type(NodeType::ROOM), attempts(0), lastAttemptMillis(0) {}
+        : room_id(0), attempts(0), lastAttemptMillis(0) {}
 };
 
 // Class to coordinate communication, data management, and web interfaces

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,18 +8,6 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:room]
-platform = espressif32
-framework = arduino
-monitor_speed = 115200
-board = esp32dev
-build_flags = 
-	-I config
-	-D MODE_ROOM
-build_src_filter = +<RoomNode/**> +<Common/**>
-lib_deps = crankyoldgit/IRremoteESP8266@^2.8.6
-upload_port = /dev/ttyUSB1
-
 [env:master]
 platform = espressif32
 board = esp32-s3-devkitm-1
@@ -35,6 +23,18 @@ lib_deps =
 	https://github.com/me-no-dev/AsyncTCP.git
 upload_port = /dev/ttyACM0
 board_build.filesystem = spiffs
+
+[env:room]
+platform = espressif32
+framework = arduino
+monitor_speed = 115200
+board = esp32dev
+build_flags = 
+	-I config
+	-D MODE_ROOM
+build_src_filter = +<RoomNode/**> +<Common/**>
+lib_deps = crankyoldgit/IRremoteESP8266@^2.8.6
+upload_port = /dev/ttyUSB1
 
 [env:sensor]
 platform = espressif32

--- a/src/SensorNode/ESPNowHandler.cpp
+++ b/src/SensorNode/ESPNowHandler.cpp
@@ -71,6 +71,7 @@ void ESPNowHandler::onDataRecv(const uint8_t* mac_addr, const uint8_t* data, int
             powerManager.updateSleepPeriod(new_sleep->new_period_ms);
             Serial.println("NEW_SLEEP_PERIOD interpreted as ACK");
             ack_received = true;
+            xSemaphoreGive(ackSemaphore);
 
             // Send ACK back to master
             AckMsg ack_msg;

--- a/src/SensorNode/SensorNode.cpp
+++ b/src/SensorNode/SensorNode.cpp
@@ -64,6 +64,9 @@ bool SensorNode::joinNetwork() {
 
 void SensorNode::run() {
     float temperature, humidity;
+
+    espNowHandler.registerPeer((uint8_t*)master_mac_addr, *channel_wifi);
+
     if (!sht31Sensor.readSensorData(temperature, humidity)) {
         Serial.println("Failed to read SHT31!");
     } else {


### PR DESCRIPTION
- MasterDevice: RAdded back the customizable sleep period functionality.
- MasterDevice: RRemoved NEW_SLEEP_PERIOD  from checkAndResendUpdate freeRTOS task as the sensor is slept most of the time.
- MasterDevice: Removed unused node_type component from PendingUpdates struct.
- SensorNode: resolved bad interpretation of NEW_SLEEP_PERIOD as ACK.
SensorNode: register peer inside run()